### PR TITLE
Add Spotless plugin for code style

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,3 +87,4 @@ dependencies {
 
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'io.fabric'
+apply from: '../spotless.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:${versions.spotlessPlugin}"
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,6 +10,7 @@ ext.versions = [
     gradlePlugin      : "3.3.0",
     googleServices    : "4.2.0",
     fabric            : "1.27.0",
+    spotlessPlugin    : '3.17.0',
 
     // AndroidX
     constraintLayout  : "1.1.3",

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -1,0 +1,17 @@
+apply plugin: "com.diffplug.gradle.spotless"
+spotless {
+  java {
+    target "**/*.java"
+    trimTrailingWhitespace()
+    removeUnusedImports()
+    googleJavaFormat()
+    endWithNewline()
+  }
+  kotlin {
+    target "**/*.kt"
+    ktlint().userData(['indent_size': '4', 'continuation_indent_size': '4'])
+    licenseHeaderFile '../spotless.license.kt'
+    trimTrailingWhitespace()
+    endWithNewline()
+  }
+}

--- a/spotless.license.kt
+++ b/spotless.license.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019 Naman Dwivedi.
+ *
+ * Licensed under the GNU General Public License v3
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ */


### PR DESCRIPTION
This will apply a consistent code style to all Java and Kotlin code across your project.

It will also automatically insert license headers at the top of every file, I've matched the one you've already been using. 

---

NOTE: I haven't run the plugin yet because the PR diff would be large and didn't want to make you look at it. If you merge this, you can run `./gradlew spotlessApply` and then push that to master.

In the future, if you use CI, builds will fail if the code style of a PR is wrong. So this helps consistency when you have many contributors.