### PR TITLE
Replace doAsync calls with Kotlin coroutines in SearchViewModel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,8 @@ android {
 dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
 
     // AndroidX
     implementation "androidx.appcompat:appcompat:${versions.appCompat}"

--- a/app/src/main/java/com/naman14/timberx/ui/viewmodels/base/ScopedViewModel.kt
+++ b/app/src/main/java/com/naman14/timberx/ui/viewmodels/base/ScopedViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import org.jetbrains.annotations.TestOnly
 import kotlin.coroutines.CoroutineContext
 
 /** @author Aidan Follestad (@afollestad) */
@@ -43,7 +42,4 @@ abstract class ScopedViewModel(
         super.onCleared()
         job.cancel()
     }
-
-    @TestOnly
-    open fun destroy() = job.cancel()
 }

--- a/app/src/main/java/com/naman14/timberx/ui/viewmodels/base/ScopedViewModel.kt
+++ b/app/src/main/java/com/naman14/timberx/ui/viewmodels/base/ScopedViewModel.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Naman Dwivedi.
+ *
+ * Licensed under the GNU General Public License v3
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ */
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package com.naman14.timberx.ui.viewmodels.base
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.jetbrains.annotations.TestOnly
+import kotlin.coroutines.CoroutineContext
+
+/** @author Aidan Follestad (@afollestad) */
+abstract class ScopedViewModel(
+    private val mainDispatcher: CoroutineDispatcher
+) : ViewModel() {
+
+    private val job = Job()
+    protected val scope = CoroutineScope(job + mainDispatcher)
+
+    protected fun launch(
+        context: CoroutineContext = mainDispatcher,
+        start: CoroutineStart = CoroutineStart.DEFAULT,
+        block: suspend CoroutineScope.() -> Unit
+    ) = scope.launch(context, start, block)
+
+    override fun onCleared() {
+        super.onCleared()
+        job.cancel()
+    }
+
+    @TestOnly
+    open fun destroy() = job.cancel()
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,11 +6,14 @@ ext.versions = [
     versionName       : "1.2",
 
     // Plugins
-    kotlin            : "1.3.20",
     gradlePlugin      : "3.3.0",
     googleServices    : "4.2.0",
     fabric            : "1.27.0",
     spotlessPlugin    : '3.17.0',
+
+    // Kotlin
+    kotlin            : "1.3.20",
+    coroutines        : '1.1.1',
 
     // AndroidX
     constraintLayout  : "1.1.3",


### PR DESCRIPTION
Replace AsyncTask with coroutines, which are scoped to the view model so execution seizes when the view model is cleared (the screen it belongs to goes away).

Part 1 of https://github.com/naman14/TimberX/issues/6.