### PR TITLE
Copy mock-secret and mock-google-services files in local builds if they don't already exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,3 @@ android:
 
 licenses:
   - '.+'
-
-before_script:
-  - cp mock/mock-google-services.json app/google-services.json
-  - cp mock/mock-secret.xml app/src/main/res/values/secret.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,3 +90,4 @@ dependencies {
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'io.fabric'
 apply from: '../spotless.gradle'
+apply from: '../mock.gradle'

--- a/mock.gradle
+++ b/mock.gradle
@@ -1,0 +1,20 @@
+// This script must be applied in app/build.gradle for the paths here to work correctly
+
+def copyMockFilesNeeded() {
+    def srcGoogleServicesFile = file("../mock/mock-google-services.json")
+    def srcCastSecretFile = file("../mock/mock-secret.xml")
+
+    def destGoogleServicesFile = file("google-services.json")
+    def destCastSecretFile = file("src/main/res/values/secret.xml")
+
+    if (!destGoogleServicesFile.exists()) {
+        destGoogleServicesFile.write(srcGoogleServicesFile.text)
+    }
+    if (!destCastSecretFile.exists()) {
+        destCastSecretFile.write(srcCastSecretFile.text)
+    }
+}
+
+afterEvaluate {
+    copyMockFilesNeeded()
+}


### PR DESCRIPTION
This allows people who check out the project, who don't have that private information, to build the app and make PRs easier to construct.