### PR TITLE
67: Fix album image in songs list

### DIFF
--- a/app/src/main/res/layout/item_songs.xml
+++ b/app/src/main/res/layout/item_songs.xml
@@ -43,7 +43,6 @@
           android:layout_height="50dp"
           android:layout_toEndOf="@+id/ivReorder"
           android:background="@drawable/default_album_art_small"
-          android:padding="1dp"
           android:scaleType="fitXY"
           app:albumArtist="@{song.artist}"
           app:albumName="@{song.album}"


### PR DESCRIPTION
Fixes #67

## Testing and Review Notes

Remove padding exceeded in image view.

## Screenshots or Videos

**Before**
![Before](https://camo.githubusercontent.com/87d71f7e5553eefbcf173c85d837f542ce26c069/68747470733a2f2f692e696d6775722e636f6d2f77314f65534f322e6a7067)

**After**
![After](https://user-images.githubusercontent.com/21011641/55282236-78ba5300-5340-11e9-9f9f-2f825052095a.jpg)

## To Do

- [X] double check the original issue to confirm it is fully satisfied
- [X] add testing notes and screenshots in PR description to help guide reviewers
- [X] run the spotlessApply task before committing.
