### PR TITLE
fix build error with latest android studio

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,7 +8,7 @@ ext.versions = [
         // Plugins
         gradlePlugin      : "3.3.1",
         googleServices    : "4.2.0",
-        fabric            : "1.27.0",
+        fabric            : "1.28.0",
         spotlessPlugin    : "3.17.0",
 
         // Kotlin


### PR DESCRIPTION
Fixing the gradle build error with the latest android studio (3.3.0).
I was getting error `API 'variant.getExternalNativeBuildTasks()' is obsolete` during building the project. Fix referenced from https://github.com/firebase/firebase-android-sdk/issues/198